### PR TITLE
org.webosport.service.devmode: Migrate to Enhanced ACG

### DIFF
--- a/files/sysbus/org.webosports.service.devmode.api.json
+++ b/files/sysbus/org.webosports.service.devmode.api.json
@@ -1,5 +1,5 @@
 {
-  "settings": [
+  "devmode-service.operation": [
       "org.webosports.service.devmode/getStatus",
       "org.webosports.service.devmode/setStatus"
   ]

--- a/files/sysbus/org.webosports.service.devmode.perm.json
+++ b/files/sysbus/org.webosports.service.devmode.perm.json
@@ -1,6 +1,6 @@
 {
     "org.webosports.service.devmode": [
-        "settings",
-        "activities.manage"
+        "devmode-service.operation",
+        "activity.operation"
     ]
 }

--- a/files/sysbus/org.webosports.service.devmode.role.json
+++ b/files/sysbus/org.webosports.service.devmode.role.json
@@ -1,6 +1,7 @@
 {
     "appId": "org.webosports.service.devmode",
     "allowedNames": ["org.webosports.service.devmode"],
+    "trustLevel" : "oem",
     "type": "regular",
     "permissions": [
         {


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
